### PR TITLE
배열 초기화 리스트

### DIFF
--- a/Dlink.vcxproj
+++ b/Dlink.vcxproj
@@ -42,6 +42,9 @@
     <ClInclude Include="include\Dlink\CommandLine.hh" />
     <ClInclude Include="include\Dlink\Lexer.hh" />
     <ClInclude Include="include\Dlink\LLVMValue.hh" />
+    <ClInclude Include="include\Dlink\Message\Error.hh" />
+    <ClInclude Include="include\Dlink\Message\Message.hh" />
+    <ClInclude Include="include\Dlink\Message\Warning.hh" />
     <ClInclude Include="include\Dlink\Parser.hh" />
     <ClInclude Include="include\Dlink\ParseStruct.hh" />
     <ClInclude Include="include\Dlink\ParseStruct\Declaration.hh" />

--- a/Dlink.vcxproj.filters
+++ b/Dlink.vcxproj.filters
@@ -16,6 +16,9 @@
     <Filter Include="Source-Files\Message">
       <UniqueIdentifier>{f9dbf609-85b5-44c9-8592-c7ee5ebf8a58}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header-Files\Message">
+      <UniqueIdentifier>{e377dca4-8f02-4997-9234-f37e6308f06e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\main.cc">
@@ -103,6 +106,15 @@
     </ClInclude>
     <ClInclude Include="include\Dlink\Any.hh">
       <Filter>Header-Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Dlink\Message\Error.hh">
+      <Filter>Header-Files\Message</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Dlink\Message\Message.hh">
+      <Filter>Header-Files\Message</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Dlink\Message\Warning.hh">
+      <Filter>Header-Files\Message</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/include/Dlink/ParseStruct/Declaration.hh
+++ b/include/Dlink/ParseStruct/Declaration.hh
@@ -13,6 +13,7 @@
 #include "llvm/IR/Value.h"
 
 #include "Root.hh"
+#include "Operation.hh"
 #include "../LLVMValue.hh"
 #include "../Token.hh"
 
@@ -27,6 +28,7 @@ namespace Dlink
 		VariableDeclaration(const Token& token, TypePtr type, const std::string& identifier, ExpressionPtr expression);
 
 		std::string tree_gen(std::size_t depth) const override;
+		void array_helper(llvm::Value* var, std::shared_ptr<ArrayInitList> array_list);
 		LLVM::Value code_gen() override;
 
 		/** 변수의 타입입니다. */

--- a/include/Dlink/ParseStruct/Operation.hh
+++ b/include/Dlink/ParseStruct/Operation.hh
@@ -92,6 +92,21 @@ namespace Dlink
 		/** 인수입니다. */
 		const std::vector<ExpressionPtr> argument;
 	};
+
+	/**
+	 * @brief 배열 초기화 리스트의 구조를 담는 추상 구문 트리의 노드입니다.
+	 * @details 이 구조체는 다른 곳에서 상속받을 수 없습니다.
+	 */
+	struct ArrayInitList final : public Expression
+	{
+		ArrayInitList(const Token& token, const std::vector<ExpressionPtr>& elements);
+
+		std::string tree_gen(std::size_t depth) const override;
+		LLVM::Value code_gen() override;
+
+		/** 배열 리스트의 원소들입니다. */
+		const std::vector<ExpressionPtr> elements;
+	};
 }
 
 namespace Dlink

--- a/include/Dlink/Parser.hh
+++ b/include/Dlink/Parser.hh
@@ -65,6 +65,7 @@ namespace Dlink
 		bool unary_plusminus(ExpressionPtr& out, Token* start_token = nullptr);
 		bool func_call(ExpressionPtr& out, Token* start_token = nullptr);
 		bool paren(ExpressionPtr& out, Token* start_token = nullptr);
+		bool array_init_list(ExpressionPtr& out, Token* start_token = nullptr);
 		bool atom(ExpressionPtr& out, Token* start_token = nullptr);
 
 		bool number(ExpressionPtr& out, Token* start_token = nullptr);

--- a/src/CodeGen.cc
+++ b/src/CodeGen.cc
@@ -14,7 +14,7 @@ namespace Dlink
 		llvm::IRBuilder<> builder(context);
 		std::unique_ptr<llvm::legacy::FunctionPassManager> function_pm;
 	}
-	
+
 	namespace CompileMessage
 	{
 		Warnings warnings;

--- a/src/ParseStruct/Declaration.cc
+++ b/src/ParseStruct/Declaration.cc
@@ -54,7 +54,7 @@ namespace Dlink
 		llvm::Value* prev_gep = LLVM::builder.CreateInBoundsGEP(var, indexList);
 
 		std::size_t i = 0;
-		for (; i < array_list->elements.size() - 1; i++)
+		for (; i < array_list->elements.size() - 1; ++i)
 		{
 			ExpressionPtr expression = array_list->elements[i];
 

--- a/src/ParseStruct/Declaration.cc
+++ b/src/ParseStruct/Declaration.cc
@@ -209,8 +209,8 @@ namespace Dlink
 	std::string UnsafeDeclaration::tree_gen(std::size_t depth) const
 	{
 		return tree_prefix(depth) + "UnsafeDeclaration:\n" +
-			tree_prefix(++depth) + "body:\n" +
-			body->tree_gen(++depth);
+			tree_prefix(depth + 1) + "body:\n" +
+			body->tree_gen(depth + 1);
 	}
 	LLVM::Value UnsafeDeclaration::code_gen()
 	{

--- a/src/ParseStruct/Declaration.cc
+++ b/src/ParseStruct/Declaration.cc
@@ -66,14 +66,16 @@ namespace Dlink
 			if ((array_list = std::dynamic_pointer_cast<ArrayInitList>(expression)))
 			{
 				std::size_t idx = 0;
+
+				llvm::Value* indexList[2] = {llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 0), 
+											 llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), idx)};
+				llvm::Value* prev_gep = LLVM::builder.CreateGEP(var, indexList);
+
 				for(ExpressionPtr expression : array_list->elements)
 				{
-					llvm::Value* indexList[2] = {llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 0), 
-												 llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), idx)};
-					llvm::Value* gep = LLVM::builder.CreateGEP(var, indexList);
-					LLVM::builder.CreateStore(expression->code_gen(), gep);
+					LLVM::builder.CreateStore(expression->code_gen(), prev_gep);
 
-					++idx;
+					prev_gep = LLVM::builder.CreateGEP(prev_gep, llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 1));
 				}
 			}
 			else

--- a/src/ParseStruct/Declaration.cc
+++ b/src/ParseStruct/Declaration.cc
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "ParseStruct/Declaration.hh"
 #include "ParseStruct/Operation.hh"
 #include "ParseStruct/Type.hh"
@@ -56,11 +58,30 @@ namespace Dlink
 		{
 			ExpressionPtr expression = array_list->elements[i];
 
-			LLVM::builder.CreateStore(expression->code_gen(), prev_gep);
-			prev_gep = LLVM::builder.CreateInBoundsGEP(prev_gep, llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 1));
+			std::shared_ptr<ArrayInitList> sub_array_list;
+			if ((sub_array_list = std::dynamic_pointer_cast<ArrayInitList>(expression)))
+			{
+				array_helper(prev_gep, sub_array_list);
+				prev_gep = LLVM::builder.CreateInBoundsGEP(prev_gep, llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 1));
+			}
+			else
+			{
+				LLVM::builder.CreateStore(expression->code_gen(), prev_gep);
+				prev_gep = LLVM::builder.CreateInBoundsGEP(prev_gep, llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 1));
+			}
 		}
 
-		LLVM::builder.CreateStore(array_list->elements[i]->code_gen(), prev_gep);
+		ExpressionPtr expression = array_list->elements[i];
+
+		std::shared_ptr<ArrayInitList> sub_array_list;
+		if ((sub_array_list = std::dynamic_pointer_cast<ArrayInitList>(expression)))
+		{
+			array_helper(prev_gep, sub_array_list);
+		}
+		else
+		{
+			LLVM::builder.CreateStore(expression->code_gen(), prev_gep);
+		}
 	}
 	LLVM::Value VariableDeclaration::code_gen()
 	{

--- a/src/ParseStruct/Declaration.cc
+++ b/src/ParseStruct/Declaration.cc
@@ -49,10 +49,10 @@ namespace Dlink
 	{
 		std::size_t idx = 0;
 
-		llvm::Value* indexList[2] = {llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 0), 
-									 llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), idx)};
+		llvm::Value* indexList[2] = { llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), 0),
+									 llvm::ConstantInt::get(LLVM::builder.getInt64Ty(), idx) };
 		llvm::Value* prev_gep = LLVM::builder.CreateInBoundsGEP(var, indexList);
-	
+
 		std::size_t i = 0;
 		for (; i < array_list->elements.size() - 1; i++)
 		{
@@ -110,7 +110,7 @@ namespace Dlink
 			else
 			{
 				LLVM::Value init_expr = expression->code_gen();
-			
+
 				LLVM::builder.CreateStore(init_expr, var);
 			}
 		}
@@ -197,11 +197,11 @@ namespace Dlink
 	LLVM::Value FunctionDeclaration::code_gen()
 	{
 		current_func = std::make_shared<FunctionDeclaration>(token, return_type, identifier, parameter, body, true);
-		
+
 		llvm::BasicBlock* func_block = llvm::BasicBlock::Create(LLVM::context, "entry", func_, nullptr);
 		LLVM::builder.SetInsertPoint(func_block);
 
-		for(auto& param : func_->args())
+		for (auto& param : func_->args())
 		{
 			llvm::AllocaInst* param_alloca = LLVM::builder.CreateAlloca(param.getType(), nullptr, param.getName());
 			LLVM::builder.CreateStore(&param, param_alloca);
@@ -222,7 +222,7 @@ namespace Dlink
 			if (LLVM::builder.getCurrentFunctionReturnType() != LLVM::builder.getVoidTy())
 			{
 				LLVM::builder.CreateRet(llvm::Constant::getNullValue(LLVM::builder.getCurrentFunctionReturnType()));
-				
+
 				CompileMessage::warnings.add_warning(Warning(token, "Expected return statement at the end of non-void returning function declaration; null value will be returned"));
 				// throw Error(token, "Expected return statement at the end of non-void returning function declaration");
 			}
@@ -234,7 +234,7 @@ namespace Dlink
 		}
 
 		LLVM::function_pm->run(*func_);
-		
+
 		for (auto& param : func_->args())
 		{
 			symbol_table->map.erase(param.getName());

--- a/src/ParseStruct/Operation.cc
+++ b/src/ParseStruct/Operation.cc
@@ -372,6 +372,10 @@ namespace Dlink
 
 		return result;
 	}
+	LLVM::Value ArrayInitList::code_gen()
+	{
+		throw Error(token, "Expected Expression");
+	}
 }
 
 namespace Dlink

--- a/src/ParseStruct/Operation.cc
+++ b/src/ParseStruct/Operation.cc
@@ -160,7 +160,7 @@ namespace Dlink
 		case TokenType::divide:
 			// TODO: 임시 방안
 			return LLVM::builder.CreateSDiv(lhs_value, rhs_value);
-		
+
 		case TokenType::assign:
 		{
 			Identifier* dest;
@@ -168,7 +168,7 @@ namespace Dlink
 			{
 				return LLVM::builder.CreateStore(rhs_value, symbol_table->find(dest->id));
 			}
-		
+
 			return LLVM::builder.CreateStore(rhs_value, lhs_value);
 		}
 
@@ -306,7 +306,7 @@ namespace Dlink
 		result += tree_prefix(depth) + "FunctionCallOperation:\n";
 		++depth;
 		result += tree_prefix(depth) + "func_expr:\n";
-		result += func_expr->tree_gen(depth+1) + '\n';
+		result += func_expr->tree_gen(depth + 1) + '\n';
 		result += tree_prefix(depth) + "argument:\n";
 		++depth;
 		for (auto arg : argument)
@@ -329,7 +329,7 @@ namespace Dlink
 		{
 			function = dynamic_cast<llvm::Function*>(func_expr->code_gen().get());
 		}
-		
+
 
 		if (function)
 		{

--- a/src/ParseStruct/Operation.cc
+++ b/src/ParseStruct/Operation.cc
@@ -349,6 +349,29 @@ namespace Dlink
 			throw Error(token, "Expected callable function expression");
 		}
 	}
+
+	/**
+	 * @brief 새 ArrayInitList 인스턴스를 만듭니다.
+	 * @param token 이 노드를 만드는데 사용된 가장 첫번째 토큰입니다.
+	 * @param elements 배열 리스트의 원소들입니다.
+	 */
+	ArrayInitList::ArrayInitList(const Token& token, const std::vector<ExpressionPtr>& elements)
+		: Expression(token), elements(elements)
+	{}
+	std::string ArrayInitList::tree_gen(std::size_t depth) const
+	{
+		std::string result;
+		result += tree_prefix(depth) + "ArrayInitList:\n";
+		++depth;
+		result += tree_prefix(depth) + "elements:\n";
+		++depth;
+		for (auto element : elements)
+		{
+			result += element->tree_gen(depth) + '\n';
+		}
+
+		return result;
+	}
 }
 
 namespace Dlink

--- a/src/ParseStruct/Operation.cc
+++ b/src/ParseStruct/Operation.cc
@@ -372,7 +372,7 @@ namespace Dlink
 	}
 	LLVM::Value ArrayInitList::code_gen()
 	{
-		throw Error(token, "Expected Expression");
+		throw Error(token, "Expected expression");
 	}
 }
 

--- a/src/ParseStruct/Root.cc
+++ b/src/ParseStruct/Root.cc
@@ -6,7 +6,7 @@
 namespace Dlink
 {
 	extern std::string tree_prefix(std::size_t depth);
-	
+
 	/**
 	 * @brief 이 Node 인스턴스의 멤버를 초기화합니다.
 	 * @param token 이 노드를 만드는데 사용된 가장 첫번째 토큰입니다.
@@ -93,7 +93,7 @@ namespace Dlink
 	Scope::Scope(const Token& token, const std::vector<StatementPtr>& statements, StatementPtr parent)
 		: Block(token, statements), parent(parent)
 	{}
-	
+
 	std::string Scope::tree_gen(std::size_t depth) const
 	{
 		std::string tree = tree_prefix(depth) + "Scope Start\n";
@@ -114,7 +114,7 @@ namespace Dlink
 		SymbolTablePtr new_symbol_table = std::make_shared<SymbolTable>();
 		new_symbol_table->parent = symbol_table;
 		symbol_table = new_symbol_table;
-		
+
 		LLVM::Value last_value;
 
 		for (StatementPtr statement : statements)

--- a/src/ParseStruct/Type.cc
+++ b/src/ParseStruct/Type.cc
@@ -65,7 +65,7 @@ namespace Dlink
 	llvm::Type* StaticArray::get_type()
 	{
 		llvm::Type* type_llvm = type->get_type();
-		std::uint64_t length_real;
+		std::uint64_t length_real = 0;
 		Any length_any;
 		bool length_ok = length->evaluate(length_any);
 		
@@ -113,6 +113,6 @@ namespace Dlink
 	std::string LValueReference::tree_gen(std::size_t depth) const
 	{
 		return tree_prefix(depth) + "LValueReference:\n" +
-			tree_prefix(++depth) + "type:\n" + type->tree_gen(++depth);
+			tree_prefix(depth + 1) + "type:\n" + type->tree_gen(depth + 1);
 	}
 }

--- a/src/ParseStruct/Type.cc
+++ b/src/ParseStruct/Type.cc
@@ -68,7 +68,7 @@ namespace Dlink
 		std::uint64_t length_real = 0;
 		Any length_any;
 		bool length_ok = length->evaluate(length_any);
-		
+
 		if (!length_ok)
 		{
 			throw Error(token, "Expected compile time integral value");

--- a/src/Parser.cc
+++ b/src/Parser.cc
@@ -578,6 +578,67 @@ namespace Dlink
 		}
 		else
 		{
+			ExpressionPtr array_list_expr;
+
+			Token list_start;
+			if (array_init_list(array_list_expr, &list_start))
+			{
+				out = array_list_expr;
+
+				assign_token(start_token, list_start);
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+	}
+
+	bool Parser::array_init_list(ExpressionPtr& out, Token* start_token)
+	{
+		Token list_start;
+		if (accept(TokenType::lbrace, &list_start))
+		{
+			if (accept(TokenType::rbrace))
+			{
+				out = std::make_shared<ArrayInitList>(list_start, std::vector<ExpressionPtr>{});
+
+				assign_token(start_token, list_start);
+				return true;
+			}
+
+			std::vector<ExpressionPtr> elements;
+
+			while (true)
+			{
+				ExpressionPtr expression;
+				expr(expression);
+				elements.push_back(expression);
+
+				if (accept(TokenType::comma))
+				{
+					continue;
+				}
+				else if (accept(TokenType::rbrace))
+				{
+					break;
+				}
+				else
+				{
+					errors_.add_error(Error(current_token(), "Expected '}' or ',', but got \"" + current_token().data + "\""));
+
+					return false;
+				}
+			}
+
+			out = std::make_shared<ArrayInitList>(list_start, elements);
+
+			assign_token(start_token, list_start);
+			return true;
+		}
+		else
+		{
 			ExpressionPtr atom_expr;
 
 			Token atom_start;

--- a/src/main.cc
+++ b/src/main.cc
@@ -13,7 +13,7 @@ int main(int argc, const char** argv)
 	lexer.lex(R"(
 	int main()
 	{
-		int[4] a = {1, 2, 3};
+		int[3] a = {1, 2, 3};
 		return 0;
 	}
 	)");

--- a/src/main.cc
+++ b/src/main.cc
@@ -13,7 +13,7 @@ int main(int argc, const char** argv)
 	lexer.lex(R"(
 	int main()
 	{
-		int[4] a = {1, 2, 3, 4};
+		int[4] a = {1, 2, 3};
 		return 0;
 	}
 	)");

--- a/src/main.cc
+++ b/src/main.cc
@@ -11,14 +11,10 @@ int main(int argc, const char** argv)
 
 	Dlink::Lexer lexer;
 	lexer.lex(R"(
-	int f(int a)
-	{
-		a = 10;
-		return a;
-	}
 	int main()
 	{
-		return f(0);
+		int[4] a = {1, 2, 3, 4};
+		return 0;
 	}
 	)");
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -13,7 +13,7 @@ int main(int argc, const char** argv)
 	lexer.lex(R"(
 	int main()
 	{
-		int[3] a = {1, 2, 3};
+		int[2][2][2] a = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
 		return 0;
 	}
 	)");


### PR DESCRIPTION
큰 문제가 없어 보입니다. 머지 합시다.
```
int[2][2][2] arr = { 1, 2, 3, 4, 5, 6, 7, 8 };
```
이 문법은 아직 지원되지 않습니다. 차후에 지원하도록 합시다.