### PR TITLE
명령줄 처리 함수 추가

### DIFF
--- a/examples/test.dl
+++ b/examples/test.dl
@@ -1,0 +1,9 @@
+unsafe int main()
+{
+	int i = 1;
+	unsafe int* ip = &i;
+	int j = *ip;
+	int* ip2 = &i;
+
+	return i;
+}

--- a/include/Dlink/CodeGen.hh
+++ b/include/Dlink/CodeGen.hh
@@ -14,6 +14,7 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Transforms/Scalar.h"
 
 #include "LLVMValue.hh"
 #include "ParseStruct/Root.hh"

--- a/include/Dlink/Init.hh
+++ b/include/Dlink/Init.hh
@@ -1,0 +1,25 @@
+#pragma once
+
+/**
+ * @file Init.hh
+ * @author dev_kr
+ * @brief Dlink 컴파일 작업의 초기 설정과 관련된 기능들의 집합입니다.
+ */
+
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <streambuf>
+
+#include "CommandLine.hh"
+#include "CodeGen.hh"
+
+namespace Dlink
+{
+	/**
+	 * @brief 명령줄 데이터 처리 함수의 반환 타입입니다.
+	 */
+	using ProcessedType = std::string;
+
+	ProcessedType ProcessCommandLine(int argc, char** argv);
+}

--- a/src/Init.cc
+++ b/src/Init.cc
@@ -1,0 +1,53 @@
+#include "Init.hh"
+
+namespace Dlink
+{
+	/**
+	 * @brief 커맨드 라인에서 파싱된 데이터를 기반으로 파일 로드 등의 작업을 수행합니다.
+	 * @param argc 명령줄의 개수입니다.
+	 * @param argv 명령줄 배열입니다.
+	 * @return 로드된 파일의 내용입니다.
+	 */
+	ProcessedType ProcessCommandLine(int argc, char** argv)
+	{
+		auto cmd_line = Dlink::ParseCommandLine(argc, argv);
+		auto cmd_line_err = Dlink::CheckError_ParsedCommandLine(cmd_line);
+		
+		if (cmd_line_err.first != Dlink::ParsedCommandLine::Error::Done)
+		{
+			throw cmd_line_err.first;
+		}
+
+		std::string code_filename;
+		long long opt_level = 0;
+
+		for (auto cmd : cmd_line)
+		{
+			if (cmd.type == Dlink::ParsedCommandLine::Type::Input)
+			{
+				code_filename = *reinterpret_cast<std::string*>(cmd.x);
+			}
+			else if(cmd.type == Dlink::ParsedCommandLine::Type::Optimize)
+			{
+				opt_level = cmd.x;
+			}
+		}
+
+		Dlink::LLVM::function_pm = std::make_unique<llvm::legacy::FunctionPassManager>(Dlink::LLVM::module.get());
+
+		if (opt_level > 0)
+		{
+			Dlink::LLVM::function_pm->add(llvm::createInstructionCombiningPass());
+			Dlink::LLVM::function_pm->add(llvm::createReassociatePass());
+			Dlink::LLVM::function_pm->add(llvm::createGVNPass());
+			Dlink::LLVM::function_pm->add(llvm::createCFGSimplificationPass());
+		}
+
+		Dlink::LLVM::function_pm->doInitialization();
+
+		std::ifstream code_file(code_filename);
+		std::string code((std::istreambuf_iterator<char>(code_file)), std::istreambuf_iterator<char>());
+
+		return code;
+	}
+}


### PR DESCRIPTION
입력 파일 로드, 최적화 모드 조절 등등의 작업을 하는 명령줄 처리 함수를 추가했습니다.

입력 : 
```
unsafe int main()
{
    int i = 1;
    int* ip = &i; 
    int j = *ip;
    int* ip2 = &i; 

    return i;
}
```

최적화 안 함의 경우(`./bin/Dlink ./examples/test.dl /O0` 또는 `/O0`은 생략 가능):

```
(렉싱/파싱 결과 생략)
Code generation Succeed
; ModuleID = 'top'

define i32 @main() {
entry:
  %i = alloca i32, align 4
  store i32 1, i32* %i
  %ip = alloca i32*, align 4
  %0 = load i32, i32* %i
  store i32* %i, i32** %ip
  %j = alloca i32, align 4
  %1 = load i32*, i32** %ip
  %2 = load i32, i32* %1
  store i32 %2, i32* %j
  %ip2 = alloca i32*, align 4
  %3 = load i32, i32* %i
  store i32* %i, i32** %ip2
  %4 = load i32, i32* %i
  ret i32 %4
}
```

최적화 함의 경우 (`./bin/Dlink ./examples/test.dl /O1` 또는 `/O1`의 1은 1 이상의 수로 대체 가능):

```
(렉싱/파싱 결과 생략)
Code generation Succeed
; ModuleID = 'top'

define i32 @main() {
entry:
  ret i32 1
}
```

아직 /IR 옵션은 처리되지 않습니다.
